### PR TITLE
Change condition expression to disable services

### DIFF
--- a/jobs/logsearch-shipper/monit
+++ b/jobs/logsearch-shipper/monit
@@ -1,11 +1,11 @@
-<% if_p('logsearch.logs.enabled') do %>
+<% if p('logsearch.logs.enabled') %>
 check process logsearch-logs with pidfile /var/vcap/sys/run/logsearch-shipper/logs.pid
   group vcap
   start program = "/var/vcap/jobs/logsearch-shipper/bin/logs.control start"
   stop program = "/var/vcap/jobs/logsearch-shipper/bin/logs.control stop"
 <% end %>
 
-<% if_p('logsearch.metrics.enabled') do %>
+<% if p('logsearch.metrics.enabled') %>
 check process logsearch-metrics with pidfile /var/vcap/sys/run/logsearch-shipper/metrics.pid
   group vcap
   start program = "/var/vcap/jobs/logsearch-shipper/bin/metrics.control start"


### PR DESCRIPTION
The condition that checks the properties to enable/disable services
(`logsearch.logs.enabled` and `logsearch.metrics.enabled`) do not
work as expected.

It only checks if the property is defined with the `if_p`, and that always
evaluate to true regardless the value of the property, even when
the value is `false:FalseClass`. Because that, there is no way to
actually disable the services.

Instead of checking if the property is defined, we must check if the
value of the property evals to true.
